### PR TITLE
Add edge operator validation

### DIFF
--- a/grammar/dot.peggy
+++ b/grammar/dot.peggy
@@ -15,6 +15,8 @@
     }
     return str;
   }
+
+  const edgeops: { operator: '--' | '->'; location: IFileRange; }[] = [];
 }
 
 start = dot
@@ -45,6 +47,17 @@ _graph
     const strict = !!_strict;
     const kind = _kind.toLowerCase();
     const directed = kind === 'digraph';
+    for (const edgeop of edgeops) {
+      if (directed) {
+        if (edgeop.operator !== '->') {
+          error(`In digraph, it's necessary to describe with "->" operator to create edge.`, edgeop.location);
+        }
+      } else {
+        if (edgeop.operator !== '--') {
+          error(`In graph, it's necessary to describe with "--" operator to create edge.`, edgeop.location);
+        }
+      }
+    }
     return id !== null ?
       { type: 'graph', id, directed, strict, body, location: location() }:
       { type: 'graph', directed, strict, body, location: location() };
@@ -112,8 +125,14 @@ _edge_target_group
 _edge_target
   = _edge_target_group / node_ref
 
+_edge_operator
+  = operator:('->'/'--') {
+    return { operator, location: location() };
+  }
+
 _edge_rhs
-  = _ edgeop:('->'/'--') _ id:_edge_target _ rest:_edge_rhs? {
+  = _ edgeop:_edge_operator _ id:_edge_target _ rest:_edge_rhs? {
+    edgeops.push(edgeop);
     return [id].concat(rest || []);
   }
 

--- a/src/__test__/__snapshots__/ast.test.ts.snap
+++ b/src/__test__/__snapshots__/ast.test.ts.snap
@@ -821,6 +821,91 @@ Object {
 }
 `;
 
+exports[`edge digraph edge 1`] = `
+Object {
+  "body": Array [],
+  "location": Object {
+    "end": Object {
+      "column": 8,
+      "line": 1,
+      "offset": 7,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "targets": Array [
+    Object {
+      "id": Object {
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 1,
+            "offset": 1,
+          },
+          "start": Object {
+            "column": 1,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+        "quoted": false,
+        "type": "literal",
+        "value": "a",
+      },
+      "location": Object {
+        "end": Object {
+          "column": 2,
+          "line": 1,
+          "offset": 1,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "node_ref",
+    },
+    Object {
+      "id": Object {
+        "location": Object {
+          "end": Object {
+            "column": 7,
+            "line": 1,
+            "offset": 6,
+          },
+          "start": Object {
+            "column": 6,
+            "line": 1,
+            "offset": 5,
+          },
+        },
+        "quoted": false,
+        "type": "literal",
+        "value": "b",
+      },
+      "location": Object {
+        "end": Object {
+          "column": 7,
+          "line": 1,
+          "offset": 6,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 1,
+          "offset": 5,
+        },
+      },
+      "type": "node_ref",
+    },
+  ],
+  "type": "edge",
+}
+`;
+
 exports[`edge edge with attributes 1`] = `
 Object {
   "body": Array [
@@ -1223,6 +1308,91 @@ Object {
 }
 `;
 
+exports[`edge graph edge 1`] = `
+Object {
+  "body": Array [],
+  "location": Object {
+    "end": Object {
+      "column": 8,
+      "line": 1,
+      "offset": 7,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "targets": Array [
+    Object {
+      "id": Object {
+        "location": Object {
+          "end": Object {
+            "column": 2,
+            "line": 1,
+            "offset": 1,
+          },
+          "start": Object {
+            "column": 1,
+            "line": 1,
+            "offset": 0,
+          },
+        },
+        "quoted": false,
+        "type": "literal",
+        "value": "a",
+      },
+      "location": Object {
+        "end": Object {
+          "column": 2,
+          "line": 1,
+          "offset": 1,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "node_ref",
+    },
+    Object {
+      "id": Object {
+        "location": Object {
+          "end": Object {
+            "column": 7,
+            "line": 1,
+            "offset": 6,
+          },
+          "start": Object {
+            "column": 6,
+            "line": 1,
+            "offset": 5,
+          },
+        },
+        "quoted": false,
+        "type": "literal",
+        "value": "b",
+      },
+      "location": Object {
+        "end": Object {
+          "column": 7,
+          "line": 1,
+          "offset": 6,
+        },
+        "start": Object {
+          "column": 6,
+          "line": 1,
+          "offset": 5,
+        },
+      },
+      "type": "node_ref",
+    },
+  ],
+  "type": "edge",
+}
+`;
+
 exports[`edge grouped edge targets 1`] = `
 Object {
   "body": Array [],
@@ -1593,91 +1763,6 @@ Object {
         "type": "node_ref",
       },
     ],
-  ],
-  "type": "edge",
-}
-`;
-
-exports[`edge simple edge 1`] = `
-Object {
-  "body": Array [],
-  "location": Object {
-    "end": Object {
-      "column": 8,
-      "line": 1,
-      "offset": 7,
-    },
-    "start": Object {
-      "column": 1,
-      "line": 1,
-      "offset": 0,
-    },
-  },
-  "targets": Array [
-    Object {
-      "id": Object {
-        "location": Object {
-          "end": Object {
-            "column": 2,
-            "line": 1,
-            "offset": 1,
-          },
-          "start": Object {
-            "column": 1,
-            "line": 1,
-            "offset": 0,
-          },
-        },
-        "quoted": false,
-        "type": "literal",
-        "value": "a",
-      },
-      "location": Object {
-        "end": Object {
-          "column": 2,
-          "line": 1,
-          "offset": 1,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-          "offset": 0,
-        },
-      },
-      "type": "node_ref",
-    },
-    Object {
-      "id": Object {
-        "location": Object {
-          "end": Object {
-            "column": 7,
-            "line": 1,
-            "offset": 6,
-          },
-          "start": Object {
-            "column": 6,
-            "line": 1,
-            "offset": 5,
-          },
-        },
-        "quoted": false,
-        "type": "literal",
-        "value": "b",
-      },
-      "location": Object {
-        "end": Object {
-          "column": 7,
-          "line": 1,
-          "offset": 6,
-        },
-        "start": Object {
-          "column": 6,
-          "line": 1,
-          "offset": 5,
-        },
-      },
-      "type": "node_ref",
-    },
   ],
   "type": "edge",
 }

--- a/src/__test__/ast.test.ts
+++ b/src/__test__/ast.test.ts
@@ -79,8 +79,13 @@ describe('attributes', () => {
 });
 
 describe('edge', () => {
-  test('simple edge', () => {
+  test('digraph edge', () => {
     const result = AST.parse('a -> b;', { rule: AST.Types.Edge });
+    expect(result).toMatchSnapshot();
+  });
+
+  test('graph edge', () => {
+    const result = AST.parse('a -- b;', { rule: AST.Types.Edge });
     expect(result).toMatchSnapshot();
   });
 
@@ -159,6 +164,36 @@ describe('graph', () => {
   test('strict graph named test', () => {
     const result = AST.parse('strict graph test {}', { rule: AST.Types.Graph });
     expect(result).toMatchSnapshot();
+  });
+
+  describe('invalid edge', () => {
+    test('digraph have to use "->" operator in edge', () => {
+      expect(() => {
+        AST.parse(
+          _`
+          digraph {
+            a -- b;
+          }`,
+          { rule: AST.Types.Graph },
+        );
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"In digraph, it's necessary to describe with \\"->\\" operator to create edge."`,
+      );
+    });
+
+    test('graph have to use "--" operator in edge', () => {
+      expect(() => {
+        AST.parse(
+          _`
+          graph {
+            a -> b;
+          }`,
+          { rule: AST.Types.Graph },
+        );
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"In graph, it's necessary to describe with \\"--\\" operator to create edge."`,
+      );
+    });
   });
 });
 

--- a/src/dot.peggy.ts
+++ b/src/dot.peggy.ts
@@ -205,6 +205,17 @@ function peg$parse(input: string, options?: IParseOptions) {
     const strict = !!_strict;
     const kind = _kind.toLowerCase();
     const directed = kind === 'digraph';
+    for (const edgeop of edgeops) {
+      if (directed) {
+        if (edgeop.operator !== '->') {
+          error(`In digraph, it's necessary to describe with "->" operator to create edge.`, edgeop.location);
+        }
+      } else {
+        if (edgeop.operator !== '--') {
+          error(`In graph, it's necessary to describe with "--" operator to create edge.`, edgeop.location);
+        }
+      }
+    }
     return id !== null
       ? { type: 'graph', id, directed, strict, body, location: location() }
       : { type: 'graph', directed, strict, body, location: location() };
@@ -273,19 +284,23 @@ function peg$parse(input: string, options?: IParseOptions) {
   const peg$c37 = peg$literalExpectation('->', false);
   const peg$c38 = '--';
   const peg$c39 = peg$literalExpectation('--', false);
-  const peg$c40 = function (edgeop: any, id: any, rest: any): any {
+  const peg$c40 = function (operator: any): any {
+    return { operator, location: location() };
+  };
+  const peg$c41 = function (edgeop: any, id: any, rest: any): any {
+    edgeops.push(edgeop);
     return [id].concat(rest || []);
   };
-  const peg$c41 = function (id: any, port: any): any {
+  const peg$c42 = function (id: any, port: any): any {
     return { type: 'node_ref', id, ...port, location: location() };
   };
-  const peg$c42 = peg$otherExpectation('port');
-  const peg$c43 = ':';
-  const peg$c44 = peg$literalExpectation(':', false);
-  const peg$c45 = function (port: any, compass: any): any {
+  const peg$c43 = peg$otherExpectation('port');
+  const peg$c44 = ':';
+  const peg$c45 = peg$literalExpectation(':', false);
+  const peg$c46 = function (port: any, compass: any): any {
     return compass;
   };
-  const peg$c46 = function (port: any, compass: any): any {
+  const peg$c47 = function (port: any, compass: any): any {
     if (['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw'].includes(port)) {
       return { compass: port };
     } else if (compass) {
@@ -293,32 +308,32 @@ function peg$parse(input: string, options?: IParseOptions) {
     }
     return { port };
   };
-  const peg$c47 = 'subgraph';
-  const peg$c48 = peg$literalExpectation('subgraph', true);
-  const peg$c49 = function (id: any): any {
+  const peg$c48 = 'subgraph';
+  const peg$c49 = peg$literalExpectation('subgraph', true);
+  const peg$c50 = function (id: any): any {
     return id;
   };
-  const peg$c50 = function (id: any, _body: any): any {
+  const peg$c51 = function (id: any, _body: any): any {
     const body = _body ?? [];
     return id ? { type: 'subgraph', id, body, location: location() } : { type: 'subgraph', body, location: location() };
   };
-  const peg$c51 = 'n';
-  const peg$c52 = peg$literalExpectation('n', false);
-  const peg$c53 = 'ne';
-  const peg$c54 = peg$literalExpectation('ne', false);
-  const peg$c55 = 'e';
-  const peg$c56 = peg$literalExpectation('e', false);
-  const peg$c57 = 'se';
-  const peg$c58 = peg$literalExpectation('se', false);
-  const peg$c59 = 's';
-  const peg$c60 = peg$literalExpectation('s', false);
-  const peg$c61 = 'sw';
-  const peg$c62 = peg$literalExpectation('sw', false);
-  const peg$c63 = 'w';
-  const peg$c64 = peg$literalExpectation('w', false);
-  const peg$c65 = 'nw';
-  const peg$c66 = peg$literalExpectation('nw', false);
-  const peg$c67 = function (value: any): any {
+  const peg$c52 = 'n';
+  const peg$c53 = peg$literalExpectation('n', false);
+  const peg$c54 = 'ne';
+  const peg$c55 = peg$literalExpectation('ne', false);
+  const peg$c56 = 'e';
+  const peg$c57 = peg$literalExpectation('e', false);
+  const peg$c58 = 'se';
+  const peg$c59 = peg$literalExpectation('se', false);
+  const peg$c60 = 's';
+  const peg$c61 = peg$literalExpectation('s', false);
+  const peg$c62 = 'sw';
+  const peg$c63 = peg$literalExpectation('sw', false);
+  const peg$c64 = 'w';
+  const peg$c65 = peg$literalExpectation('w', false);
+  const peg$c66 = 'nw';
+  const peg$c67 = peg$literalExpectation('nw', false);
+  const peg$c68 = function (value: any): any {
     return {
       type: 'literal',
       value,
@@ -326,15 +341,15 @@ function peg$parse(input: string, options?: IParseOptions) {
       location: location(),
     };
   };
-  const peg$c68 = '/*';
-  const peg$c69 = peg$literalExpectation('/*', false);
-  const peg$c70 = '*/';
-  const peg$c71 = peg$literalExpectation('*/', false);
-  const peg$c72 = peg$anyExpectation();
-  const peg$c73 = function (v: any): any {
+  const peg$c69 = '/*';
+  const peg$c70 = peg$literalExpectation('/*', false);
+  const peg$c71 = '*/';
+  const peg$c72 = peg$literalExpectation('*/', false);
+  const peg$c73 = peg$anyExpectation();
+  const peg$c74 = function (v: any): any {
     return v;
   };
-  const peg$c74 = function (v: any): any {
+  const peg$c75 = function (v: any): any {
     return {
       type: 'comment',
       kind: 'block',
@@ -342,7 +357,7 @@ function peg$parse(input: string, options?: IParseOptions) {
       location: location(),
     };
   };
-  const peg$c75 = function (lines: any): any {
+  const peg$c76 = function (lines: any): any {
     return {
       type: 'comment',
       kind: 'slash',
@@ -350,12 +365,12 @@ function peg$parse(input: string, options?: IParseOptions) {
       location: location(),
     };
   };
-  const peg$c76 = '//';
-  const peg$c77 = peg$literalExpectation('//', false);
-  const peg$c78 = function (v: any): any {
+  const peg$c77 = '//';
+  const peg$c78 = peg$literalExpectation('//', false);
+  const peg$c79 = function (v: any): any {
     return v.join('');
   };
-  const peg$c79 = function (lines: any): any {
+  const peg$c80 = function (lines: any): any {
     return {
       type: 'comment',
       kind: 'macro',
@@ -363,30 +378,30 @@ function peg$parse(input: string, options?: IParseOptions) {
       location: location(),
     };
   };
-  const peg$c80 = '#';
-  const peg$c81 = peg$literalExpectation('#', false);
-  const peg$c82 = peg$otherExpectation('UNICODE_STRING');
-  const peg$c83 = function (first: any, rest: any): any {
+  const peg$c81 = '#';
+  const peg$c82 = peg$literalExpectation('#', false);
+  const peg$c83 = peg$otherExpectation('UNICODE_STRING');
+  const peg$c84 = function (first: any, rest: any): any {
     return first + rest.join('');
   };
-  const peg$c84 = function (first: any, rest: any): any {
+  const peg$c85 = function (first: any, rest: any): any {
     return first + rest;
   };
-  const peg$c85 = '$';
-  const peg$c86 = peg$literalExpectation('$', false);
-  const peg$c87 = '_';
-  const peg$c88 = peg$literalExpectation('_', false);
-  const peg$c89 = peg$otherExpectation('NUMBER');
-  const peg$c90 = '-';
-  const peg$c91 = peg$literalExpectation('-', false);
-  const peg$c92 = '.';
-  const peg$c93 = peg$literalExpectation('.', false);
-  const peg$c94 = /^[0-9]/;
-  const peg$c95 = peg$classExpectation([['0', '9']], false, false);
-  const peg$c96 = function (n: any): any {
+  const peg$c86 = '$';
+  const peg$c87 = peg$literalExpectation('$', false);
+  const peg$c88 = '_';
+  const peg$c89 = peg$literalExpectation('_', false);
+  const peg$c90 = peg$otherExpectation('NUMBER');
+  const peg$c91 = '-';
+  const peg$c92 = peg$literalExpectation('-', false);
+  const peg$c93 = '.';
+  const peg$c94 = peg$literalExpectation('.', false);
+  const peg$c95 = /^[0-9]/;
+  const peg$c96 = peg$classExpectation([['0', '9']], false, false);
+  const peg$c97 = function (n: any): any {
     return parseFloat(text());
   };
-  const peg$c97 = function (v: any): any {
+  const peg$c98 = function (v: any): any {
     return {
       type: 'literal',
       value: v.slice(1, v.length - 1),
@@ -394,19 +409,19 @@ function peg$parse(input: string, options?: IParseOptions) {
       location: location(),
     };
   };
-  const peg$c98 = '<';
-  const peg$c99 = peg$literalExpectation('<', false);
-  const peg$c100 = '>';
-  const peg$c101 = peg$literalExpectation('>', false);
-  const peg$c102 = function (v: any): any {
+  const peg$c99 = '<';
+  const peg$c100 = peg$literalExpectation('<', false);
+  const peg$c101 = '>';
+  const peg$c102 = peg$literalExpectation('>', false);
+  const peg$c103 = function (v: any): any {
     return '<' + v.join('') + '>';
   };
-  const peg$c103 = function (v: any): any {
+  const peg$c104 = function (v: any): any {
     return v.join('');
   };
-  const peg$c104 = '"';
-  const peg$c105 = peg$literalExpectation('"', false);
-  const peg$c106 = function (chars: any): any {
+  const peg$c105 = '"';
+  const peg$c106 = peg$literalExpectation('"', false);
+  const peg$c107 = function (chars: any): any {
     return {
       type: 'literal',
       value: chars.join(''),
@@ -414,51 +429,51 @@ function peg$parse(input: string, options?: IParseOptions) {
       location: location(),
     };
   };
-  const peg$c107 = function (): any {
+  const peg$c108 = function (): any {
     return text();
   };
-  const peg$c108 = '\\';
-  const peg$c109 = peg$literalExpectation('\\', false);
-  const peg$c110 = function (v: any): any {
+  const peg$c109 = '\\';
+  const peg$c110 = peg$literalExpectation('\\', false);
+  const peg$c111 = function (v: any): any {
     return v[1] === '"' ? '"' : v[0] + v[1];
   };
-  const peg$c111 = function (): any {
+  const peg$c112 = function (): any {
     return '';
   };
-  const peg$c112 = /^[\n\r\u2028\u2029]/;
-  const peg$c113 = peg$classExpectation(['\n', '\r', '\u2028', '\u2029'], false, false);
-  const peg$c114 = peg$otherExpectation('end of line');
-  const peg$c115 = '\n';
-  const peg$c116 = peg$literalExpectation('\n', false);
-  const peg$c117 = '\r\n';
-  const peg$c118 = peg$literalExpectation('\r\n', false);
-  const peg$c119 = '\r';
-  const peg$c120 = peg$literalExpectation('\r', false);
-  const peg$c121 = '\u2028';
-  const peg$c122 = peg$literalExpectation('\u2028', false);
-  const peg$c123 = '\u2029';
-  const peg$c124 = peg$literalExpectation('\u2029', false);
-  const peg$c125 = function (chars: any): any {
+  const peg$c113 = /^[\n\r\u2028\u2029]/;
+  const peg$c114 = peg$classExpectation(['\n', '\r', '\u2028', '\u2029'], false, false);
+  const peg$c115 = peg$otherExpectation('end of line');
+  const peg$c116 = '\n';
+  const peg$c117 = peg$literalExpectation('\n', false);
+  const peg$c118 = '\r\n';
+  const peg$c119 = peg$literalExpectation('\r\n', false);
+  const peg$c120 = '\r';
+  const peg$c121 = peg$literalExpectation('\r', false);
+  const peg$c122 = '\u2028';
+  const peg$c123 = peg$literalExpectation('\u2028', false);
+  const peg$c124 = '\u2029';
+  const peg$c125 = peg$literalExpectation('\u2029', false);
+  const peg$c126 = function (chars: any): any {
     return chars.join('');
   };
-  const peg$c126 = /^[^"\\\0-\x1F\x7F]/;
-  const peg$c127 = peg$classExpectation(['"', '\\', ['\0', '\x1F'], '\x7F'], true, false);
-  const peg$c128 = '\\"';
-  const peg$c129 = peg$literalExpectation('\\"', false);
-  const peg$c130 = function (): any {
+  const peg$c127 = /^[^"\\\0-\x1F\x7F]/;
+  const peg$c128 = peg$classExpectation(['"', '\\', ['\0', '\x1F'], '\x7F'], true, false);
+  const peg$c129 = '\\"';
+  const peg$c130 = peg$literalExpectation('\\"', false);
+  const peg$c131 = function (): any {
     return '"';
   };
-  const peg$c131 = function (): any {
+  const peg$c132 = function (): any {
     return '\\';
   };
-  const peg$c132 = peg$otherExpectation('whitespace');
-  const peg$c133 = peg$otherExpectation('WHITESPACE');
-  const peg$c134 = /^[\n\r]/;
-  const peg$c135 = peg$classExpectation(['\n', '\r'], false, false);
-  const peg$c136 = /^[ \t]/;
-  const peg$c137 = peg$classExpectation([' ', '\t'], false, false);
-  const peg$c138 = /^[a-z\xB5\xDF-\xF6\xF8-\xFF\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137-\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148-\u0149\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\u017A\u017C\u017E-\u0180\u0183\u0185\u0188\u018C-\u018D\u0192\u0195\u0199-\u019B\u019E\u01A1\u01A3\u01A5\u01A8\u01AA-\u01AB\u01AD\u01B0\u01B4\u01B6\u01B9-\u01BA\u01BD-\u01BF\u01C6\u01C9\u01CC\u01CE\u01D0\u01D2\u01D4\u01D6\u01D8\u01DA\u01DC-\u01DD\u01DF\u01E1\u01E3\u01E5\u01E7\u01E9\u01EB\u01ED\u01EF-\u01F0\u01F3\u01F5\u01F9\u01FB\u01FD\u01FF\u0201\u0203\u0205\u0207\u0209\u020B\u020D\u020F\u0211\u0213\u0215\u0217\u0219\u021B\u021D\u021F\u0221\u0223\u0225\u0227\u0229\u022B\u022D\u022F\u0231\u0233-\u0239\u023C\u023F-\u0240\u0242\u0247\u0249\u024B\u024D\u024F-\u0293\u0295-\u02AF\u0371\u0373\u0377\u037B-\u037D\u0390\u03AC-\u03CE\u03D0-\u03D1\u03D5-\u03D7\u03D9\u03DB\u03DD\u03DF\u03E1\u03E3\u03E5\u03E7\u03E9\u03EB\u03ED\u03EF-\u03F3\u03F5\u03F8\u03FB-\u03FC\u0430-\u045F\u0461\u0463\u0465\u0467\u0469\u046B\u046D\u046F\u0471\u0473\u0475\u0477\u0479\u047B\u047D\u047F\u0481\u048B\u048D\u048F\u0491\u0493\u0495\u0497\u0499\u049B\u049D\u049F\u04A1\u04A3\u04A5\u04A7\u04A9\u04AB\u04AD\u04AF\u04B1\u04B3\u04B5\u04B7\u04B9\u04BB\u04BD\u04BF\u04C2\u04C4\u04C6\u04C8\u04CA\u04CC\u04CE-\u04CF\u04D1\u04D3\u04D5\u04D7\u04D9\u04DB\u04DD\u04DF\u04E1\u04E3\u04E5\u04E7\u04E9\u04EB\u04ED\u04EF\u04F1\u04F3\u04F5\u04F7\u04F9\u04FB\u04FD\u04FF\u0501\u0503\u0505\u0507\u0509\u050B\u050D\u050F\u0511\u0513\u0515\u0517\u0519\u051B\u051D\u051F\u0521\u0523\u0525\u0527\u0561-\u0587\u1D00-\u1D2B\u1D6B-\u1D77\u1D79-\u1D9A\u1E01\u1E03\u1E05\u1E07\u1E09\u1E0B\u1E0D\u1E0F\u1E11\u1E13\u1E15\u1E17\u1E19\u1E1B\u1E1D\u1E1F\u1E21\u1E23\u1E25\u1E27\u1E29\u1E2B\u1E2D\u1E2F\u1E31\u1E33\u1E35\u1E37\u1E39\u1E3B\u1E3D\u1E3F\u1E41\u1E43\u1E45\u1E47\u1E49\u1E4B\u1E4D\u1E4F\u1E51\u1E53\u1E55\u1E57\u1E59\u1E5B\u1E5D\u1E5F\u1E61\u1E63\u1E65\u1E67\u1E69\u1E6B\u1E6D\u1E6F\u1E71\u1E73\u1E75\u1E77\u1E79\u1E7B\u1E7D\u1E7F\u1E81\u1E83\u1E85\u1E87\u1E89\u1E8B\u1E8D\u1E8F\u1E91\u1E93\u1E95-\u1E9D\u1E9F\u1EA1\u1EA3\u1EA5\u1EA7\u1EA9\u1EAB\u1EAD\u1EAF\u1EB1\u1EB3\u1EB5\u1EB7\u1EB9\u1EBB\u1EBD\u1EBF\u1EC1\u1EC3\u1EC5\u1EC7\u1EC9\u1ECB\u1ECD\u1ECF\u1ED1\u1ED3\u1ED5\u1ED7\u1ED9\u1EDB\u1EDD\u1EDF\u1EE1\u1EE3\u1EE5\u1EE7\u1EE9\u1EEB\u1EED\u1EEF\u1EF1\u1EF3\u1EF5\u1EF7\u1EF9\u1EFB\u1EFD\u1EFF-\u1F07\u1F10-\u1F15\u1F20-\u1F27\u1F30-\u1F37\u1F40-\u1F45\u1F50-\u1F57\u1F60-\u1F67\u1F70-\u1F7D\u1F80-\u1F87\u1F90-\u1F97\u1FA0-\u1FA7\u1FB0-\u1FB4\u1FB6-\u1FB7\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FC7\u1FD0-\u1FD3\u1FD6-\u1FD7\u1FE0-\u1FE7\u1FF2-\u1FF4\u1FF6-\u1FF7\u210A\u210E-\u210F\u2113\u212F\u2134\u2139\u213C-\u213D\u2146-\u2149\u214E\u2184\u2C30-\u2C5E\u2C61\u2C65-\u2C66\u2C68\u2C6A\u2C6C\u2C71\u2C73-\u2C74\u2C76-\u2C7B\u2C81\u2C83\u2C85\u2C87\u2C89\u2C8B\u2C8D\u2C8F\u2C91\u2C93\u2C95\u2C97\u2C99\u2C9B\u2C9D\u2C9F\u2CA1\u2CA3\u2CA5\u2CA7\u2CA9\u2CAB\u2CAD\u2CAF\u2CB1\u2CB3\u2CB5\u2CB7\u2CB9\u2CBB\u2CBD\u2CBF\u2CC1\u2CC3\u2CC5\u2CC7\u2CC9\u2CCB\u2CCD\u2CCF\u2CD1\u2CD3\u2CD5\u2CD7\u2CD9\u2CDB\u2CDD\u2CDF\u2CE1\u2CE3-\u2CE4\u2CEC\u2CEE\u2CF3\u2D00-\u2D25\u2D27\u2D2D\uA641\uA643\uA645\uA647\uA649\uA64B\uA64D\uA64F\uA651\uA653\uA655\uA657\uA659\uA65B\uA65D\uA65F\uA661\uA663\uA665\uA667\uA669\uA66B\uA66D\uA681\uA683\uA685\uA687\uA689\uA68B\uA68D\uA68F\uA691\uA693\uA695\uA697\uA723\uA725\uA727\uA729\uA72B\uA72D\uA72F-\uA731\uA733\uA735\uA737\uA739\uA73B\uA73D\uA73F\uA741\uA743\uA745\uA747\uA749\uA74B\uA74D\uA74F\uA751\uA753\uA755\uA757\uA759\uA75B\uA75D\uA75F\uA761\uA763\uA765\uA767\uA769\uA76B\uA76D\uA76F\uA771-\uA778\uA77A\uA77C\uA77F\uA781\uA783\uA785\uA787\uA78C\uA78E\uA791\uA793\uA7A1\uA7A3\uA7A5\uA7A7\uA7A9\uA7FA\uFB00-\uFB06\uFB13-\uFB17\uFF41-\uFF5A]/;
-  const peg$c139 = peg$classExpectation(
+  const peg$c133 = peg$otherExpectation('whitespace');
+  const peg$c134 = peg$otherExpectation('WHITESPACE');
+  const peg$c135 = /^[\n\r]/;
+  const peg$c136 = peg$classExpectation(['\n', '\r'], false, false);
+  const peg$c137 = /^[ \t]/;
+  const peg$c138 = peg$classExpectation([' ', '\t'], false, false);
+  const peg$c139 = /^[a-z\xB5\xDF-\xF6\xF8-\xFF\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137-\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148-\u0149\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\u017A\u017C\u017E-\u0180\u0183\u0185\u0188\u018C-\u018D\u0192\u0195\u0199-\u019B\u019E\u01A1\u01A3\u01A5\u01A8\u01AA-\u01AB\u01AD\u01B0\u01B4\u01B6\u01B9-\u01BA\u01BD-\u01BF\u01C6\u01C9\u01CC\u01CE\u01D0\u01D2\u01D4\u01D6\u01D8\u01DA\u01DC-\u01DD\u01DF\u01E1\u01E3\u01E5\u01E7\u01E9\u01EB\u01ED\u01EF-\u01F0\u01F3\u01F5\u01F9\u01FB\u01FD\u01FF\u0201\u0203\u0205\u0207\u0209\u020B\u020D\u020F\u0211\u0213\u0215\u0217\u0219\u021B\u021D\u021F\u0221\u0223\u0225\u0227\u0229\u022B\u022D\u022F\u0231\u0233-\u0239\u023C\u023F-\u0240\u0242\u0247\u0249\u024B\u024D\u024F-\u0293\u0295-\u02AF\u0371\u0373\u0377\u037B-\u037D\u0390\u03AC-\u03CE\u03D0-\u03D1\u03D5-\u03D7\u03D9\u03DB\u03DD\u03DF\u03E1\u03E3\u03E5\u03E7\u03E9\u03EB\u03ED\u03EF-\u03F3\u03F5\u03F8\u03FB-\u03FC\u0430-\u045F\u0461\u0463\u0465\u0467\u0469\u046B\u046D\u046F\u0471\u0473\u0475\u0477\u0479\u047B\u047D\u047F\u0481\u048B\u048D\u048F\u0491\u0493\u0495\u0497\u0499\u049B\u049D\u049F\u04A1\u04A3\u04A5\u04A7\u04A9\u04AB\u04AD\u04AF\u04B1\u04B3\u04B5\u04B7\u04B9\u04BB\u04BD\u04BF\u04C2\u04C4\u04C6\u04C8\u04CA\u04CC\u04CE-\u04CF\u04D1\u04D3\u04D5\u04D7\u04D9\u04DB\u04DD\u04DF\u04E1\u04E3\u04E5\u04E7\u04E9\u04EB\u04ED\u04EF\u04F1\u04F3\u04F5\u04F7\u04F9\u04FB\u04FD\u04FF\u0501\u0503\u0505\u0507\u0509\u050B\u050D\u050F\u0511\u0513\u0515\u0517\u0519\u051B\u051D\u051F\u0521\u0523\u0525\u0527\u0561-\u0587\u1D00-\u1D2B\u1D6B-\u1D77\u1D79-\u1D9A\u1E01\u1E03\u1E05\u1E07\u1E09\u1E0B\u1E0D\u1E0F\u1E11\u1E13\u1E15\u1E17\u1E19\u1E1B\u1E1D\u1E1F\u1E21\u1E23\u1E25\u1E27\u1E29\u1E2B\u1E2D\u1E2F\u1E31\u1E33\u1E35\u1E37\u1E39\u1E3B\u1E3D\u1E3F\u1E41\u1E43\u1E45\u1E47\u1E49\u1E4B\u1E4D\u1E4F\u1E51\u1E53\u1E55\u1E57\u1E59\u1E5B\u1E5D\u1E5F\u1E61\u1E63\u1E65\u1E67\u1E69\u1E6B\u1E6D\u1E6F\u1E71\u1E73\u1E75\u1E77\u1E79\u1E7B\u1E7D\u1E7F\u1E81\u1E83\u1E85\u1E87\u1E89\u1E8B\u1E8D\u1E8F\u1E91\u1E93\u1E95-\u1E9D\u1E9F\u1EA1\u1EA3\u1EA5\u1EA7\u1EA9\u1EAB\u1EAD\u1EAF\u1EB1\u1EB3\u1EB5\u1EB7\u1EB9\u1EBB\u1EBD\u1EBF\u1EC1\u1EC3\u1EC5\u1EC7\u1EC9\u1ECB\u1ECD\u1ECF\u1ED1\u1ED3\u1ED5\u1ED7\u1ED9\u1EDB\u1EDD\u1EDF\u1EE1\u1EE3\u1EE5\u1EE7\u1EE9\u1EEB\u1EED\u1EEF\u1EF1\u1EF3\u1EF5\u1EF7\u1EF9\u1EFB\u1EFD\u1EFF-\u1F07\u1F10-\u1F15\u1F20-\u1F27\u1F30-\u1F37\u1F40-\u1F45\u1F50-\u1F57\u1F60-\u1F67\u1F70-\u1F7D\u1F80-\u1F87\u1F90-\u1F97\u1FA0-\u1FA7\u1FB0-\u1FB4\u1FB6-\u1FB7\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FC7\u1FD0-\u1FD3\u1FD6-\u1FD7\u1FE0-\u1FE7\u1FF2-\u1FF4\u1FF6-\u1FF7\u210A\u210E-\u210F\u2113\u212F\u2134\u2139\u213C-\u213D\u2146-\u2149\u214E\u2184\u2C30-\u2C5E\u2C61\u2C65-\u2C66\u2C68\u2C6A\u2C6C\u2C71\u2C73-\u2C74\u2C76-\u2C7B\u2C81\u2C83\u2C85\u2C87\u2C89\u2C8B\u2C8D\u2C8F\u2C91\u2C93\u2C95\u2C97\u2C99\u2C9B\u2C9D\u2C9F\u2CA1\u2CA3\u2CA5\u2CA7\u2CA9\u2CAB\u2CAD\u2CAF\u2CB1\u2CB3\u2CB5\u2CB7\u2CB9\u2CBB\u2CBD\u2CBF\u2CC1\u2CC3\u2CC5\u2CC7\u2CC9\u2CCB\u2CCD\u2CCF\u2CD1\u2CD3\u2CD5\u2CD7\u2CD9\u2CDB\u2CDD\u2CDF\u2CE1\u2CE3-\u2CE4\u2CEC\u2CEE\u2CF3\u2D00-\u2D25\u2D27\u2D2D\uA641\uA643\uA645\uA647\uA649\uA64B\uA64D\uA64F\uA651\uA653\uA655\uA657\uA659\uA65B\uA65D\uA65F\uA661\uA663\uA665\uA667\uA669\uA66B\uA66D\uA681\uA683\uA685\uA687\uA689\uA68B\uA68D\uA68F\uA691\uA693\uA695\uA697\uA723\uA725\uA727\uA729\uA72B\uA72D\uA72F-\uA731\uA733\uA735\uA737\uA739\uA73B\uA73D\uA73F\uA741\uA743\uA745\uA747\uA749\uA74B\uA74D\uA74F\uA751\uA753\uA755\uA757\uA759\uA75B\uA75D\uA75F\uA761\uA763\uA765\uA767\uA769\uA76B\uA76D\uA76F\uA771-\uA778\uA77A\uA77C\uA77F\uA781\uA783\uA785\uA787\uA78C\uA78E\uA791\uA793\uA7A1\uA7A3\uA7A5\uA7A7\uA7A9\uA7FA\uFB00-\uFB06\uFB13-\uFB17\uFF41-\uFF5A]/;
+  const peg$c140 = peg$classExpectation(
     [
       ['a', 'z'],
       '\xB5',
@@ -1046,8 +1061,8 @@ function peg$parse(input: string, options?: IParseOptions) {
     false,
     false,
   );
-  const peg$c140 = /^[\u02B0-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0374\u037A\u0559\u0640\u06E5-\u06E6\u07F4-\u07F5\u07FA\u081A\u0824\u0828\u0971\u0E46\u0EC6\u10FC\u17D7\u1843\u1AA7\u1C78-\u1C7D\u1D2C-\u1D6A\u1D78\u1D9B-\u1DBF\u2071\u207F\u2090-\u209C\u2C7C-\u2C7D\u2D6F\u2E2F\u3005\u3031-\u3035\u303B\u309D-\u309E\u30FC-\u30FE\uA015\uA4F8-\uA4FD\uA60C\uA67F\uA717-\uA71F\uA770\uA788\uA7F8-\uA7F9\uA9CF\uAA70\uAADD\uAAF3-\uAAF4\uFF70\uFF9E-\uFF9F]/;
-  const peg$c141 = peg$classExpectation(
+  const peg$c141 = /^[\u02B0-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0374\u037A\u0559\u0640\u06E5-\u06E6\u07F4-\u07F5\u07FA\u081A\u0824\u0828\u0971\u0E46\u0EC6\u10FC\u17D7\u1843\u1AA7\u1C78-\u1C7D\u1D2C-\u1D6A\u1D78\u1D9B-\u1DBF\u2071\u207F\u2090-\u209C\u2C7C-\u2C7D\u2D6F\u2E2F\u3005\u3031-\u3035\u303B\u309D-\u309E\u30FC-\u30FE\uA015\uA4F8-\uA4FD\uA60C\uA67F\uA717-\uA71F\uA770\uA788\uA7F8-\uA7F9\uA9CF\uAA70\uAADD\uAAF3-\uAAF4\uFF70\uFF9E-\uFF9F]/;
+  const peg$c142 = peg$classExpectation(
     [
       ['\u02B0', '\u02C1'],
       ['\u02C6', '\u02D1'],
@@ -1104,8 +1119,8 @@ function peg$parse(input: string, options?: IParseOptions) {
     false,
     false,
   );
-  const peg$c142 = /^[\xAA\xBA\u01BB\u01C0-\u01C3\u0294\u05D0-\u05EA\u05F0-\u05F2\u0620-\u063F\u0641-\u064A\u066E-\u066F\u0671-\u06D3\u06D5\u06EE-\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u0800-\u0815\u0840-\u0858\u08A0\u08A2-\u08AC\u0904-\u0939\u093D\u0950\u0958-\u0961\u0972-\u0977\u0979-\u097F\u0985-\u098C\u098F-\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC-\u09DD\u09DF-\u09E1\u09F0-\u09F1\u0A05-\u0A0A\u0A0F-\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32-\u0A33\u0A35-\u0A36\u0A38-\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2-\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0-\u0AE1\u0B05-\u0B0C\u0B0F-\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32-\u0B33\u0B35-\u0B39\u0B3D\u0B5C-\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99-\u0B9A\u0B9C\u0B9E-\u0B9F\u0BA3-\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C33\u0C35-\u0C39\u0C3D\u0C58-\u0C59\u0C60-\u0C61\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0-\u0CE1\u0CF1-\u0CF2\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D60-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32-\u0E33\u0E40-\u0E45\u0E81-\u0E82\u0E84\u0E87-\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA-\u0EAB\u0EAD-\u0EB0\u0EB2-\u0EB3\u0EBD\u0EC0-\u0EC4\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065-\u1066\u106E-\u1070\u1075-\u1081\u108E\u10D0-\u10FA\u10FD-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F4\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17DC\u1820-\u1842\u1844-\u1877\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191C\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19C1-\u19C7\u1A00-\u1A16\u1A20-\u1A54\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE-\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C77\u1CE9-\u1CEC\u1CEE-\u1CF1\u1CF5-\u1CF6\u2135-\u2138\u2D30-\u2D67\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3006\u303C\u3041-\u3096\u309F\u30A1-\u30FA\u30FF\u3105-\u312D\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400-\u4DB5\u4E00-\u9FCC\uA000-\uA014\uA016-\uA48C\uA4D0-\uA4F7\uA500-\uA60B\uA610-\uA61F\uA62A-\uA62B\uA66E\uA6A0-\uA6E5\uA7FB-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA6F\uAA71-\uAA76\uAA7A\uAA80-\uAAAF\uAAB1\uAAB5-\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADC\uAAE0-\uAAEA\uAAF2\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uABC0-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40-\uFB41\uFB43-\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF66-\uFF6F\uFF71-\uFF9D\uFFA0-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]/;
-  const peg$c143 = peg$classExpectation(
+  const peg$c143 = /^[\xAA\xBA\u01BB\u01C0-\u01C3\u0294\u05D0-\u05EA\u05F0-\u05F2\u0620-\u063F\u0641-\u064A\u066E-\u066F\u0671-\u06D3\u06D5\u06EE-\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u0800-\u0815\u0840-\u0858\u08A0\u08A2-\u08AC\u0904-\u0939\u093D\u0950\u0958-\u0961\u0972-\u0977\u0979-\u097F\u0985-\u098C\u098F-\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC-\u09DD\u09DF-\u09E1\u09F0-\u09F1\u0A05-\u0A0A\u0A0F-\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32-\u0A33\u0A35-\u0A36\u0A38-\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2-\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0-\u0AE1\u0B05-\u0B0C\u0B0F-\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32-\u0B33\u0B35-\u0B39\u0B3D\u0B5C-\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99-\u0B9A\u0B9C\u0B9E-\u0B9F\u0BA3-\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C33\u0C35-\u0C39\u0C3D\u0C58-\u0C59\u0C60-\u0C61\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0-\u0CE1\u0CF1-\u0CF2\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D60-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32-\u0E33\u0E40-\u0E45\u0E81-\u0E82\u0E84\u0E87-\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA-\u0EAB\u0EAD-\u0EB0\u0EB2-\u0EB3\u0EBD\u0EC0-\u0EC4\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065-\u1066\u106E-\u1070\u1075-\u1081\u108E\u10D0-\u10FA\u10FD-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F4\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17DC\u1820-\u1842\u1844-\u1877\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191C\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19C1-\u19C7\u1A00-\u1A16\u1A20-\u1A54\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE-\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C77\u1CE9-\u1CEC\u1CEE-\u1CF1\u1CF5-\u1CF6\u2135-\u2138\u2D30-\u2D67\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3006\u303C\u3041-\u3096\u309F\u30A1-\u30FA\u30FF\u3105-\u312D\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400-\u4DB5\u4E00-\u9FCC\uA000-\uA014\uA016-\uA48C\uA4D0-\uA4F7\uA500-\uA60B\uA610-\uA61F\uA62A-\uA62B\uA66E\uA6A0-\uA6E5\uA7FB-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA6F\uAA71-\uAA76\uAA7A\uAA80-\uAAAF\uAAB1\uAAB5-\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADC\uAAE0-\uAAEA\uAAF2\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uABC0-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40-\uFB41\uFB43-\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF66-\uFF6F\uFF71-\uFF9D\uFFA0-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]/;
+  const peg$c144 = peg$classExpectation(
     [
       '\xAA',
       '\xBA',
@@ -1397,8 +1412,8 @@ function peg$parse(input: string, options?: IParseOptions) {
     false,
     false,
   );
-  const peg$c144 = /^[\u01C5\u01C8\u01CB\u01F2\u1F88-\u1F8F\u1F98-\u1F9F\u1FA8-\u1FAF\u1FBC\u1FCC\u1FFC]/;
-  const peg$c145 = peg$classExpectation(
+  const peg$c145 = /^[\u01C5\u01C8\u01CB\u01F2\u1F88-\u1F8F\u1F98-\u1F9F\u1FA8-\u1FAF\u1FBC\u1FCC\u1FFC]/;
+  const peg$c146 = peg$classExpectation(
     [
       '\u01C5',
       '\u01C8',
@@ -1414,8 +1429,8 @@ function peg$parse(input: string, options?: IParseOptions) {
     false,
     false,
   );
-  const peg$c146 = /^[A-Z\xC0-\xD6\xD8-\xDE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178-\u0179\u017B\u017D\u0181-\u0182\u0184\u0186-\u0187\u0189-\u018B\u018E-\u0191\u0193-\u0194\u0196-\u0198\u019C-\u019D\u019F-\u01A0\u01A2\u01A4\u01A6-\u01A7\u01A9\u01AC\u01AE-\u01AF\u01B1-\u01B3\u01B5\u01B7-\u01B8\u01BC\u01C4\u01C7\u01CA\u01CD\u01CF\u01D1\u01D3\u01D5\u01D7\u01D9\u01DB\u01DE\u01E0\u01E2\u01E4\u01E6\u01E8\u01EA\u01EC\u01EE\u01F1\u01F4\u01F6-\u01F8\u01FA\u01FC\u01FE\u0200\u0202\u0204\u0206\u0208\u020A\u020C\u020E\u0210\u0212\u0214\u0216\u0218\u021A\u021C\u021E\u0220\u0222\u0224\u0226\u0228\u022A\u022C\u022E\u0230\u0232\u023A-\u023B\u023D-\u023E\u0241\u0243-\u0246\u0248\u024A\u024C\u024E\u0370\u0372\u0376\u0386\u0388-\u038A\u038C\u038E-\u038F\u0391-\u03A1\u03A3-\u03AB\u03CF\u03D2-\u03D4\u03D8\u03DA\u03DC\u03DE\u03E0\u03E2\u03E4\u03E6\u03E8\u03EA\u03EC\u03EE\u03F4\u03F7\u03F9-\u03FA\u03FD-\u042F\u0460\u0462\u0464\u0466\u0468\u046A\u046C\u046E\u0470\u0472\u0474\u0476\u0478\u047A\u047C\u047E\u0480\u048A\u048C\u048E\u0490\u0492\u0494\u0496\u0498\u049A\u049C\u049E\u04A0\u04A2\u04A4\u04A6\u04A8\u04AA\u04AC\u04AE\u04B0\u04B2\u04B4\u04B6\u04B8\u04BA\u04BC\u04BE\u04C0-\u04C1\u04C3\u04C5\u04C7\u04C9\u04CB\u04CD\u04D0\u04D2\u04D4\u04D6\u04D8\u04DA\u04DC\u04DE\u04E0\u04E2\u04E4\u04E6\u04E8\u04EA\u04EC\u04EE\u04F0\u04F2\u04F4\u04F6\u04F8\u04FA\u04FC\u04FE\u0500\u0502\u0504\u0506\u0508\u050A\u050C\u050E\u0510\u0512\u0514\u0516\u0518\u051A\u051C\u051E\u0520\u0522\u0524\u0526\u0531-\u0556\u10A0-\u10C5\u10C7\u10CD\u1E00\u1E02\u1E04\u1E06\u1E08\u1E0A\u1E0C\u1E0E\u1E10\u1E12\u1E14\u1E16\u1E18\u1E1A\u1E1C\u1E1E\u1E20\u1E22\u1E24\u1E26\u1E28\u1E2A\u1E2C\u1E2E\u1E30\u1E32\u1E34\u1E36\u1E38\u1E3A\u1E3C\u1E3E\u1E40\u1E42\u1E44\u1E46\u1E48\u1E4A\u1E4C\u1E4E\u1E50\u1E52\u1E54\u1E56\u1E58\u1E5A\u1E5C\u1E5E\u1E60\u1E62\u1E64\u1E66\u1E68\u1E6A\u1E6C\u1E6E\u1E70\u1E72\u1E74\u1E76\u1E78\u1E7A\u1E7C\u1E7E\u1E80\u1E82\u1E84\u1E86\u1E88\u1E8A\u1E8C\u1E8E\u1E90\u1E92\u1E94\u1E9E\u1EA0\u1EA2\u1EA4\u1EA6\u1EA8\u1EAA\u1EAC\u1EAE\u1EB0\u1EB2\u1EB4\u1EB6\u1EB8\u1EBA\u1EBC\u1EBE\u1EC0\u1EC2\u1EC4\u1EC6\u1EC8\u1ECA\u1ECC\u1ECE\u1ED0\u1ED2\u1ED4\u1ED6\u1ED8\u1EDA\u1EDC\u1EDE\u1EE0\u1EE2\u1EE4\u1EE6\u1EE8\u1EEA\u1EEC\u1EEE\u1EF0\u1EF2\u1EF4\u1EF6\u1EF8\u1EFA\u1EFC\u1EFE\u1F08-\u1F0F\u1F18-\u1F1D\u1F28-\u1F2F\u1F38-\u1F3F\u1F48-\u1F4D\u1F59\u1F5B\u1F5D\u1F5F\u1F68-\u1F6F\u1FB8-\u1FBB\u1FC8-\u1FCB\u1FD8-\u1FDB\u1FE8-\u1FEC\u1FF8-\u1FFB\u2102\u2107\u210B-\u210D\u2110-\u2112\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u2130-\u2133\u213E-\u213F\u2145\u2183\u2C00-\u2C2E\u2C60\u2C62-\u2C64\u2C67\u2C69\u2C6B\u2C6D-\u2C70\u2C72\u2C75\u2C7E-\u2C80\u2C82\u2C84\u2C86\u2C88\u2C8A\u2C8C\u2C8E\u2C90\u2C92\u2C94\u2C96\u2C98\u2C9A\u2C9C\u2C9E\u2CA0\u2CA2\u2CA4\u2CA6\u2CA8\u2CAA\u2CAC\u2CAE\u2CB0\u2CB2\u2CB4\u2CB6\u2CB8\u2CBA\u2CBC\u2CBE\u2CC0\u2CC2\u2CC4\u2CC6\u2CC8\u2CCA\u2CCC\u2CCE\u2CD0\u2CD2\u2CD4\u2CD6\u2CD8\u2CDA\u2CDC\u2CDE\u2CE0\u2CE2\u2CEB\u2CED\u2CF2\uA640\uA642\uA644\uA646\uA648\uA64A\uA64C\uA64E\uA650\uA652\uA654\uA656\uA658\uA65A\uA65C\uA65E\uA660\uA662\uA664\uA666\uA668\uA66A\uA66C\uA680\uA682\uA684\uA686\uA688\uA68A\uA68C\uA68E\uA690\uA692\uA694\uA696\uA722\uA724\uA726\uA728\uA72A\uA72C\uA72E\uA732\uA734\uA736\uA738\uA73A\uA73C\uA73E\uA740\uA742\uA744\uA746\uA748\uA74A\uA74C\uA74E\uA750\uA752\uA754\uA756\uA758\uA75A\uA75C\uA75E\uA760\uA762\uA764\uA766\uA768\uA76A\uA76C\uA76E\uA779\uA77B\uA77D-\uA77E\uA780\uA782\uA784\uA786\uA78B\uA78D\uA790\uA792\uA7A0\uA7A2\uA7A4\uA7A6\uA7A8\uA7AA\uFF21-\uFF3A]/;
-  const peg$c147 = peg$classExpectation(
+  const peg$c147 = /^[A-Z\xC0-\xD6\xD8-\xDE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178-\u0179\u017B\u017D\u0181-\u0182\u0184\u0186-\u0187\u0189-\u018B\u018E-\u0191\u0193-\u0194\u0196-\u0198\u019C-\u019D\u019F-\u01A0\u01A2\u01A4\u01A6-\u01A7\u01A9\u01AC\u01AE-\u01AF\u01B1-\u01B3\u01B5\u01B7-\u01B8\u01BC\u01C4\u01C7\u01CA\u01CD\u01CF\u01D1\u01D3\u01D5\u01D7\u01D9\u01DB\u01DE\u01E0\u01E2\u01E4\u01E6\u01E8\u01EA\u01EC\u01EE\u01F1\u01F4\u01F6-\u01F8\u01FA\u01FC\u01FE\u0200\u0202\u0204\u0206\u0208\u020A\u020C\u020E\u0210\u0212\u0214\u0216\u0218\u021A\u021C\u021E\u0220\u0222\u0224\u0226\u0228\u022A\u022C\u022E\u0230\u0232\u023A-\u023B\u023D-\u023E\u0241\u0243-\u0246\u0248\u024A\u024C\u024E\u0370\u0372\u0376\u0386\u0388-\u038A\u038C\u038E-\u038F\u0391-\u03A1\u03A3-\u03AB\u03CF\u03D2-\u03D4\u03D8\u03DA\u03DC\u03DE\u03E0\u03E2\u03E4\u03E6\u03E8\u03EA\u03EC\u03EE\u03F4\u03F7\u03F9-\u03FA\u03FD-\u042F\u0460\u0462\u0464\u0466\u0468\u046A\u046C\u046E\u0470\u0472\u0474\u0476\u0478\u047A\u047C\u047E\u0480\u048A\u048C\u048E\u0490\u0492\u0494\u0496\u0498\u049A\u049C\u049E\u04A0\u04A2\u04A4\u04A6\u04A8\u04AA\u04AC\u04AE\u04B0\u04B2\u04B4\u04B6\u04B8\u04BA\u04BC\u04BE\u04C0-\u04C1\u04C3\u04C5\u04C7\u04C9\u04CB\u04CD\u04D0\u04D2\u04D4\u04D6\u04D8\u04DA\u04DC\u04DE\u04E0\u04E2\u04E4\u04E6\u04E8\u04EA\u04EC\u04EE\u04F0\u04F2\u04F4\u04F6\u04F8\u04FA\u04FC\u04FE\u0500\u0502\u0504\u0506\u0508\u050A\u050C\u050E\u0510\u0512\u0514\u0516\u0518\u051A\u051C\u051E\u0520\u0522\u0524\u0526\u0531-\u0556\u10A0-\u10C5\u10C7\u10CD\u1E00\u1E02\u1E04\u1E06\u1E08\u1E0A\u1E0C\u1E0E\u1E10\u1E12\u1E14\u1E16\u1E18\u1E1A\u1E1C\u1E1E\u1E20\u1E22\u1E24\u1E26\u1E28\u1E2A\u1E2C\u1E2E\u1E30\u1E32\u1E34\u1E36\u1E38\u1E3A\u1E3C\u1E3E\u1E40\u1E42\u1E44\u1E46\u1E48\u1E4A\u1E4C\u1E4E\u1E50\u1E52\u1E54\u1E56\u1E58\u1E5A\u1E5C\u1E5E\u1E60\u1E62\u1E64\u1E66\u1E68\u1E6A\u1E6C\u1E6E\u1E70\u1E72\u1E74\u1E76\u1E78\u1E7A\u1E7C\u1E7E\u1E80\u1E82\u1E84\u1E86\u1E88\u1E8A\u1E8C\u1E8E\u1E90\u1E92\u1E94\u1E9E\u1EA0\u1EA2\u1EA4\u1EA6\u1EA8\u1EAA\u1EAC\u1EAE\u1EB0\u1EB2\u1EB4\u1EB6\u1EB8\u1EBA\u1EBC\u1EBE\u1EC0\u1EC2\u1EC4\u1EC6\u1EC8\u1ECA\u1ECC\u1ECE\u1ED0\u1ED2\u1ED4\u1ED6\u1ED8\u1EDA\u1EDC\u1EDE\u1EE0\u1EE2\u1EE4\u1EE6\u1EE8\u1EEA\u1EEC\u1EEE\u1EF0\u1EF2\u1EF4\u1EF6\u1EF8\u1EFA\u1EFC\u1EFE\u1F08-\u1F0F\u1F18-\u1F1D\u1F28-\u1F2F\u1F38-\u1F3F\u1F48-\u1F4D\u1F59\u1F5B\u1F5D\u1F5F\u1F68-\u1F6F\u1FB8-\u1FBB\u1FC8-\u1FCB\u1FD8-\u1FDB\u1FE8-\u1FEC\u1FF8-\u1FFB\u2102\u2107\u210B-\u210D\u2110-\u2112\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u2130-\u2133\u213E-\u213F\u2145\u2183\u2C00-\u2C2E\u2C60\u2C62-\u2C64\u2C67\u2C69\u2C6B\u2C6D-\u2C70\u2C72\u2C75\u2C7E-\u2C80\u2C82\u2C84\u2C86\u2C88\u2C8A\u2C8C\u2C8E\u2C90\u2C92\u2C94\u2C96\u2C98\u2C9A\u2C9C\u2C9E\u2CA0\u2CA2\u2CA4\u2CA6\u2CA8\u2CAA\u2CAC\u2CAE\u2CB0\u2CB2\u2CB4\u2CB6\u2CB8\u2CBA\u2CBC\u2CBE\u2CC0\u2CC2\u2CC4\u2CC6\u2CC8\u2CCA\u2CCC\u2CCE\u2CD0\u2CD2\u2CD4\u2CD6\u2CD8\u2CDA\u2CDC\u2CDE\u2CE0\u2CE2\u2CEB\u2CED\u2CF2\uA640\uA642\uA644\uA646\uA648\uA64A\uA64C\uA64E\uA650\uA652\uA654\uA656\uA658\uA65A\uA65C\uA65E\uA660\uA662\uA664\uA666\uA668\uA66A\uA66C\uA680\uA682\uA684\uA686\uA688\uA68A\uA68C\uA68E\uA690\uA692\uA694\uA696\uA722\uA724\uA726\uA728\uA72A\uA72C\uA72E\uA732\uA734\uA736\uA738\uA73A\uA73C\uA73E\uA740\uA742\uA744\uA746\uA748\uA74A\uA74C\uA74E\uA750\uA752\uA754\uA756\uA758\uA75A\uA75C\uA75E\uA760\uA762\uA764\uA766\uA768\uA76A\uA76C\uA76E\uA779\uA77B\uA77D-\uA77E\uA780\uA782\uA784\uA786\uA78B\uA78D\uA790\uA792\uA7A0\uA7A2\uA7A4\uA7A6\uA7A8\uA7AA\uFF21-\uFF3A]/;
+  const peg$c148 = peg$classExpectation(
     [
       ['A', 'Z'],
       ['\xC0', '\xD6'],
@@ -1997,8 +2012,8 @@ function peg$parse(input: string, options?: IParseOptions) {
     false,
     false,
   );
-  const peg$c148 = /^[\u16EE-\u16F0\u2160-\u2182\u2185-\u2188\u3007\u3021-\u3029\u3038-\u303A\uA6E6-\uA6EF]/;
-  const peg$c149 = peg$classExpectation(
+  const peg$c149 = /^[\u16EE-\u16F0\u2160-\u2182\u2185-\u2188\u3007\u3021-\u3029\u3038-\u303A\uA6E6-\uA6EF]/;
+  const peg$c150 = peg$classExpectation(
     [
       ['\u16EE', '\u16F0'],
       ['\u2160', '\u2182'],
@@ -2011,8 +2026,8 @@ function peg$parse(input: string, options?: IParseOptions) {
     false,
     false,
   );
-  const peg$c150 = /^[0-9\u0660-\u0669\u06F0-\u06F9\u07C0-\u07C9\u0966-\u096F\u09E6-\u09EF\u0A66-\u0A6F\u0AE6-\u0AEF\u0B66-\u0B6F\u0BE6-\u0BEF\u0C66-\u0C6F\u0CE6-\u0CEF\u0D66-\u0D6F\u0E50-\u0E59\u0ED0-\u0ED9\u0F20-\u0F29\u1040-\u1049\u1090-\u1099\u17E0-\u17E9\u1810-\u1819\u1946-\u194F\u19D0-\u19D9\u1A80-\u1A89\u1A90-\u1A99\u1B50-\u1B59\u1BB0-\u1BB9\u1C40-\u1C49\u1C50-\u1C59\uA620-\uA629\uA8D0-\uA8D9\uA900-\uA909\uA9D0-\uA9D9\uAA50-\uAA59\uABF0-\uABF9\uFF10-\uFF19]/;
-  const peg$c151 = peg$classExpectation(
+  const peg$c151 = /^[0-9\u0660-\u0669\u06F0-\u06F9\u07C0-\u07C9\u0966-\u096F\u09E6-\u09EF\u0A66-\u0A6F\u0AE6-\u0AEF\u0B66-\u0B6F\u0BE6-\u0BEF\u0C66-\u0C6F\u0CE6-\u0CEF\u0D66-\u0D6F\u0E50-\u0E59\u0ED0-\u0ED9\u0F20-\u0F29\u1040-\u1049\u1090-\u1099\u17E0-\u17E9\u1810-\u1819\u1946-\u194F\u19D0-\u19D9\u1A80-\u1A89\u1A90-\u1A99\u1B50-\u1B59\u1BB0-\u1BB9\u1C40-\u1C49\u1C50-\u1C59\uA620-\uA629\uA8D0-\uA8D9\uA900-\uA909\uA9D0-\uA9D9\uAA50-\uAA59\uABF0-\uABF9\uFF10-\uFF19]/;
+  const peg$c152 = peg$classExpectation(
     [
       ['0', '9'],
       ['\u0660', '\u0669'],
@@ -3164,32 +3179,46 @@ function peg$parse(input: string, options?: IParseOptions) {
     return s0;
   }
 
+  function peg$parse_edge_operator(): any {
+    let s0, s1;
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 2) === peg$c36) {
+      s1 = peg$c36;
+      peg$currPos += 2;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) {
+        peg$fail(peg$c37);
+      }
+    }
+    if ((s1 as any) === peg$FAILED) {
+      if (input.substr(peg$currPos, 2) === peg$c38) {
+        s1 = peg$c38;
+        peg$currPos += 2;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) {
+          peg$fail(peg$c39);
+        }
+      }
+    }
+    if ((s1 as any) !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c40(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
   function peg$parse_edge_rhs(): any {
     let s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
     s1 = peg$parse_();
     if ((s1 as any) !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c36) {
-        s2 = peg$c36;
-        peg$currPos += 2;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) {
-          peg$fail(peg$c37);
-        }
-      }
-      if ((s2 as any) === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c38) {
-          s2 = peg$c38;
-          peg$currPos += 2;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) {
-            peg$fail(peg$c39);
-          }
-        }
-      }
+      s2 = peg$parse_edge_operator();
       if ((s2 as any) !== peg$FAILED) {
         s3 = peg$parse_();
         if ((s3 as any) !== peg$FAILED) {
@@ -3203,7 +3232,7 @@ function peg$parse(input: string, options?: IParseOptions) {
               }
               if ((s6 as any) !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c40(s2, s4, s6);
+                s1 = peg$c41(s2, s4, s6);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -3245,7 +3274,7 @@ function peg$parse(input: string, options?: IParseOptions) {
       }
       if ((s2 as any) !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c41(s1, s2);
+        s1 = peg$c42(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3265,12 +3294,12 @@ function peg$parse(input: string, options?: IParseOptions) {
     peg$silentFails++;
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 58) {
-      s1 = peg$c43;
+      s1 = peg$c44;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c44);
+        peg$fail(peg$c45);
       }
     }
     if ((s1 as any) !== peg$FAILED) {
@@ -3278,19 +3307,19 @@ function peg$parse(input: string, options?: IParseOptions) {
       if ((s2 as any) !== peg$FAILED) {
         s3 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 58) {
-          s4 = peg$c43;
+          s4 = peg$c44;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c44);
+            peg$fail(peg$c45);
           }
         }
         if ((s4 as any) !== peg$FAILED) {
           s5 = peg$parse_compass();
           if ((s5 as any) !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c45(s2, s5);
+            s4 = peg$c46(s2, s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -3305,7 +3334,7 @@ function peg$parse(input: string, options?: IParseOptions) {
         }
         if ((s3 as any) !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c46(s2, s3);
+          s1 = peg$c47(s2, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3323,7 +3352,7 @@ function peg$parse(input: string, options?: IParseOptions) {
     if ((s0 as any) === peg$FAILED) {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c42);
+        peg$fail(peg$c43);
       }
     }
 
@@ -3334,13 +3363,13 @@ function peg$parse(input: string, options?: IParseOptions) {
     let s0, s1, s2, s3, s4;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c47) {
+    if (input.substr(peg$currPos, 8).toLowerCase() === peg$c48) {
       s1 = input.substr(peg$currPos, 8);
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c48);
+        peg$fail(peg$c49);
       }
     }
     if ((s1 as any) !== peg$FAILED) {
@@ -3354,7 +3383,7 @@ function peg$parse(input: string, options?: IParseOptions) {
           s4 = peg$parse_();
           if ((s4 as any) !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c49(s3);
+            s1 = peg$c50(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3413,7 +3442,7 @@ function peg$parse(input: string, options?: IParseOptions) {
             }
             if ((s5 as any) !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c50(s1, s3);
+              s1 = peg$c51(s1, s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -3443,82 +3472,82 @@ function peg$parse(input: string, options?: IParseOptions) {
     let s0;
 
     if (input.charCodeAt(peg$currPos) === 110) {
-      s0 = peg$c51;
+      s0 = peg$c52;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c52);
+        peg$fail(peg$c53);
       }
     }
     if ((s0 as any) === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c53) {
-        s0 = peg$c53;
+      if (input.substr(peg$currPos, 2) === peg$c54) {
+        s0 = peg$c54;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
         if (peg$silentFails === 0) {
-          peg$fail(peg$c54);
+          peg$fail(peg$c55);
         }
       }
       if ((s0 as any) === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 101) {
-          s0 = peg$c55;
+          s0 = peg$c56;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c56);
+            peg$fail(peg$c57);
           }
         }
         if ((s0 as any) === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c57) {
-            s0 = peg$c57;
+          if (input.substr(peg$currPos, 2) === peg$c58) {
+            s0 = peg$c58;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
             if (peg$silentFails === 0) {
-              peg$fail(peg$c58);
+              peg$fail(peg$c59);
             }
           }
           if ((s0 as any) === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 115) {
-              s0 = peg$c59;
+              s0 = peg$c60;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
               if (peg$silentFails === 0) {
-                peg$fail(peg$c60);
+                peg$fail(peg$c61);
               }
             }
             if ((s0 as any) === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c61) {
-                s0 = peg$c61;
+              if (input.substr(peg$currPos, 2) === peg$c62) {
+                s0 = peg$c62;
                 peg$currPos += 2;
               } else {
                 s0 = peg$FAILED;
                 if (peg$silentFails === 0) {
-                  peg$fail(peg$c62);
+                  peg$fail(peg$c63);
                 }
               }
               if ((s0 as any) === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 119) {
-                  s0 = peg$c63;
+                  s0 = peg$c64;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
                   if (peg$silentFails === 0) {
-                    peg$fail(peg$c64);
+                    peg$fail(peg$c65);
                   }
                 }
                 if ((s0 as any) === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c65) {
-                    s0 = peg$c65;
+                  if (input.substr(peg$currPos, 2) === peg$c66) {
+                    s0 = peg$c66;
                     peg$currPos += 2;
                   } else {
                     s0 = peg$FAILED;
                     if (peg$silentFails === 0) {
-                      peg$fail(peg$c66);
+                      peg$fail(peg$c67);
                     }
                   }
                 }
@@ -3549,7 +3578,7 @@ function peg$parse(input: string, options?: IParseOptions) {
         }
         if ((s1 as any) !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c67(s1);
+          s1 = peg$c68(s1);
         }
         s0 = s1;
       }
@@ -3576,13 +3605,13 @@ function peg$parse(input: string, options?: IParseOptions) {
     let s0, s1, s2, s3, s4, s5;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c68) {
-      s1 = peg$c68;
+    if (input.substr(peg$currPos, 2) === peg$c69) {
+      s1 = peg$c69;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c69);
+        peg$fail(peg$c70);
       }
     }
     if ((s1 as any) !== peg$FAILED) {
@@ -3590,13 +3619,13 @@ function peg$parse(input: string, options?: IParseOptions) {
       s3 = peg$currPos;
       s4 = peg$currPos;
       peg$silentFails++;
-      if (input.substr(peg$currPos, 2) === peg$c70) {
-        s5 = peg$c70;
+      if (input.substr(peg$currPos, 2) === peg$c71) {
+        s5 = peg$c71;
         peg$currPos += 2;
       } else {
         s5 = peg$FAILED;
         if (peg$silentFails === 0) {
-          peg$fail(peg$c71);
+          peg$fail(peg$c72);
         }
       }
       peg$silentFails--;
@@ -3613,12 +3642,12 @@ function peg$parse(input: string, options?: IParseOptions) {
         } else {
           s5 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c72);
+            peg$fail(peg$c73);
           }
         }
         if ((s5 as any) !== peg$FAILED) {
           peg$savedPos = s3;
-          s4 = peg$c73(s5);
+          s4 = peg$c74(s5);
           s3 = s4;
         } else {
           peg$currPos = s3;
@@ -3633,13 +3662,13 @@ function peg$parse(input: string, options?: IParseOptions) {
         s3 = peg$currPos;
         s4 = peg$currPos;
         peg$silentFails++;
-        if (input.substr(peg$currPos, 2) === peg$c70) {
-          s5 = peg$c70;
+        if (input.substr(peg$currPos, 2) === peg$c71) {
+          s5 = peg$c71;
           peg$currPos += 2;
         } else {
           s5 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c71);
+            peg$fail(peg$c72);
           }
         }
         peg$silentFails--;
@@ -3656,12 +3685,12 @@ function peg$parse(input: string, options?: IParseOptions) {
           } else {
             s5 = peg$FAILED;
             if (peg$silentFails === 0) {
-              peg$fail(peg$c72);
+              peg$fail(peg$c73);
             }
           }
           if ((s5 as any) !== peg$FAILED) {
             peg$savedPos = s3;
-            s4 = peg$c73(s5);
+            s4 = peg$c74(s5);
             s3 = s4;
           } else {
             peg$currPos = s3;
@@ -3673,18 +3702,18 @@ function peg$parse(input: string, options?: IParseOptions) {
         }
       }
       if ((s2 as any) !== peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c70) {
-          s3 = peg$c70;
+        if (input.substr(peg$currPos, 2) === peg$c71) {
+          s3 = peg$c71;
           peg$currPos += 2;
         } else {
           s3 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c71);
+            peg$fail(peg$c72);
           }
         }
         if ((s3 as any) !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c74(s2);
+          s1 = peg$c75(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3718,7 +3747,7 @@ function peg$parse(input: string, options?: IParseOptions) {
     }
     if ((s1 as any) !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c75(s1);
+      s1 = peg$c76(s1);
     }
     s0 = s1;
 
@@ -3731,13 +3760,13 @@ function peg$parse(input: string, options?: IParseOptions) {
     s0 = peg$currPos;
     s1 = peg$parse_();
     if ((s1 as any) !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c76) {
-        s2 = peg$c76;
+      if (input.substr(peg$currPos, 2) === peg$c77) {
+        s2 = peg$c77;
         peg$currPos += 2;
       } else {
         s2 = peg$FAILED;
         if (peg$silentFails === 0) {
-          peg$fail(peg$c77);
+          peg$fail(peg$c78);
         }
       }
       if ((s2 as any) !== peg$FAILED) {
@@ -3760,7 +3789,7 @@ function peg$parse(input: string, options?: IParseOptions) {
           } else {
             s6 = peg$FAILED;
             if (peg$silentFails === 0) {
-              peg$fail(peg$c72);
+              peg$fail(peg$c73);
             }
           }
           if ((s6 as any) !== peg$FAILED) {
@@ -3795,7 +3824,7 @@ function peg$parse(input: string, options?: IParseOptions) {
             } else {
               s6 = peg$FAILED;
               if (peg$silentFails === 0) {
-                peg$fail(peg$c72);
+                peg$fail(peg$c73);
               }
             }
             if ((s6 as any) !== peg$FAILED) {
@@ -3818,7 +3847,7 @@ function peg$parse(input: string, options?: IParseOptions) {
           }
           if ((s4 as any) !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c78(s3);
+            s1 = peg$c79(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3856,7 +3885,7 @@ function peg$parse(input: string, options?: IParseOptions) {
     }
     if ((s1 as any) !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c79(s1);
+      s1 = peg$c80(s1);
     }
     s0 = s1;
 
@@ -3870,12 +3899,12 @@ function peg$parse(input: string, options?: IParseOptions) {
     s1 = peg$parse_();
     if ((s1 as any) !== peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 35) {
-        s2 = peg$c80;
+        s2 = peg$c81;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
         if (peg$silentFails === 0) {
-          peg$fail(peg$c81);
+          peg$fail(peg$c82);
         }
       }
       if ((s2 as any) !== peg$FAILED) {
@@ -3898,7 +3927,7 @@ function peg$parse(input: string, options?: IParseOptions) {
           } else {
             s6 = peg$FAILED;
             if (peg$silentFails === 0) {
-              peg$fail(peg$c72);
+              peg$fail(peg$c73);
             }
           }
           if ((s6 as any) !== peg$FAILED) {
@@ -3933,7 +3962,7 @@ function peg$parse(input: string, options?: IParseOptions) {
             } else {
               s6 = peg$FAILED;
               if (peg$silentFails === 0) {
-                peg$fail(peg$c72);
+                peg$fail(peg$c73);
               }
             }
             if ((s6 as any) !== peg$FAILED) {
@@ -3956,7 +3985,7 @@ function peg$parse(input: string, options?: IParseOptions) {
           }
           if ((s4 as any) !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c78(s3);
+            s1 = peg$c79(s3);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -3993,7 +4022,7 @@ function peg$parse(input: string, options?: IParseOptions) {
       }
       if ((s2 as any) !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c83(s1, s2);
+        s1 = peg$c84(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4007,7 +4036,7 @@ function peg$parse(input: string, options?: IParseOptions) {
     if ((s0 as any) === peg$FAILED) {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c82);
+        peg$fail(peg$c83);
       }
     }
 
@@ -4023,7 +4052,7 @@ function peg$parse(input: string, options?: IParseOptions) {
       s2 = peg$parseSTRING();
       if ((s2 as any) !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c84(s1, s2);
+        s1 = peg$c85(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4043,22 +4072,22 @@ function peg$parse(input: string, options?: IParseOptions) {
     s0 = peg$parseUnicodeLetter();
     if ((s0 as any) === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 36) {
-        s0 = peg$c85;
+        s0 = peg$c86;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
         if (peg$silentFails === 0) {
-          peg$fail(peg$c86);
+          peg$fail(peg$c87);
         }
       }
       if ((s0 as any) === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 95) {
-          s0 = peg$c87;
+          s0 = peg$c88;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c88);
+            peg$fail(peg$c89);
           }
         }
       }
@@ -4085,12 +4114,12 @@ function peg$parse(input: string, options?: IParseOptions) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s2 = peg$c90;
+      s2 = peg$c91;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c91);
+        peg$fail(peg$c92);
       }
     }
     if ((s2 as any) === peg$FAILED) {
@@ -4099,35 +4128,35 @@ function peg$parse(input: string, options?: IParseOptions) {
     if ((s2 as any) !== peg$FAILED) {
       s3 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s4 = peg$c92;
+        s4 = peg$c93;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
         if (peg$silentFails === 0) {
-          peg$fail(peg$c93);
+          peg$fail(peg$c94);
         }
       }
       if ((s4 as any) !== peg$FAILED) {
         s5 = [];
-        if (peg$c94.test(input.charAt(peg$currPos))) {
+        if (peg$c95.test(input.charAt(peg$currPos))) {
           s6 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s6 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c95);
+            peg$fail(peg$c96);
           }
         }
         if ((s6 as any) !== peg$FAILED) {
           while ((s6 as any) !== peg$FAILED) {
             s5.push(s6);
-            if (peg$c94.test(input.charAt(peg$currPos))) {
+            if (peg$c95.test(input.charAt(peg$currPos))) {
               s6 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
               if (peg$silentFails === 0) {
-                peg$fail(peg$c95);
+                peg$fail(peg$c96);
               }
             }
           }
@@ -4148,25 +4177,25 @@ function peg$parse(input: string, options?: IParseOptions) {
       if ((s3 as any) === peg$FAILED) {
         s3 = peg$currPos;
         s4 = [];
-        if (peg$c94.test(input.charAt(peg$currPos))) {
+        if (peg$c95.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c95);
+            peg$fail(peg$c96);
           }
         }
         if ((s5 as any) !== peg$FAILED) {
           while ((s5 as any) !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c94.test(input.charAt(peg$currPos))) {
+            if (peg$c95.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
               if (peg$silentFails === 0) {
-                peg$fail(peg$c95);
+                peg$fail(peg$c96);
               }
             }
           }
@@ -4176,34 +4205,34 @@ function peg$parse(input: string, options?: IParseOptions) {
         if ((s4 as any) !== peg$FAILED) {
           s5 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 46) {
-            s6 = peg$c92;
+            s6 = peg$c93;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
             if (peg$silentFails === 0) {
-              peg$fail(peg$c93);
+              peg$fail(peg$c94);
             }
           }
           if ((s6 as any) !== peg$FAILED) {
             s7 = [];
-            if (peg$c94.test(input.charAt(peg$currPos))) {
+            if (peg$c95.test(input.charAt(peg$currPos))) {
               s8 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s8 = peg$FAILED;
               if (peg$silentFails === 0) {
-                peg$fail(peg$c95);
+                peg$fail(peg$c96);
               }
             }
             while ((s8 as any) !== peg$FAILED) {
               s7.push(s8);
-              if (peg$c94.test(input.charAt(peg$currPos))) {
+              if (peg$c95.test(input.charAt(peg$currPos))) {
                 s8 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s8 = peg$FAILED;
                 if (peg$silentFails === 0) {
-                  peg$fail(peg$c95);
+                  peg$fail(peg$c96);
                 }
               }
             }
@@ -4246,14 +4275,14 @@ function peg$parse(input: string, options?: IParseOptions) {
     }
     if ((s1 as any) !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c96(s1);
+      s1 = peg$c97(s1);
     }
     s0 = s1;
     peg$silentFails--;
     if ((s0 as any) === peg$FAILED) {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c89);
+        peg$fail(peg$c90);
       }
     }
 
@@ -4267,7 +4296,7 @@ function peg$parse(input: string, options?: IParseOptions) {
     s1 = peg$parsehtml_raw_string();
     if ((s1 as any) !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c97(s1);
+      s1 = peg$c98(s1);
     }
     s0 = s1;
 
@@ -4279,12 +4308,12 @@ function peg$parse(input: string, options?: IParseOptions) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 60) {
-      s1 = peg$c98;
+      s1 = peg$c99;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c99);
+        peg$fail(peg$c100);
       }
     }
     if ((s1 as any) !== peg$FAILED) {
@@ -4302,17 +4331,17 @@ function peg$parse(input: string, options?: IParseOptions) {
       }
       if ((s2 as any) !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 62) {
-          s3 = peg$c100;
+          s3 = peg$c101;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c101);
+            peg$fail(peg$c102);
           }
         }
         if ((s3 as any) !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c102(s2);
+          s1 = peg$c103(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4339,22 +4368,22 @@ function peg$parse(input: string, options?: IParseOptions) {
     s3 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 62) {
-      s4 = peg$c100;
+      s4 = peg$c101;
       peg$currPos++;
     } else {
       s4 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c101);
+        peg$fail(peg$c102);
       }
     }
     if ((s4 as any) === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 60) {
-        s4 = peg$c98;
+        s4 = peg$c99;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
         if (peg$silentFails === 0) {
-          peg$fail(peg$c99);
+          peg$fail(peg$c100);
         }
       }
     }
@@ -4372,7 +4401,7 @@ function peg$parse(input: string, options?: IParseOptions) {
       } else {
         s4 = peg$FAILED;
         if (peg$silentFails === 0) {
-          peg$fail(peg$c72);
+          peg$fail(peg$c73);
         }
       }
       if ((s4 as any) !== peg$FAILED) {
@@ -4394,22 +4423,22 @@ function peg$parse(input: string, options?: IParseOptions) {
         s3 = peg$currPos;
         peg$silentFails++;
         if (input.charCodeAt(peg$currPos) === 62) {
-          s4 = peg$c100;
+          s4 = peg$c101;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c101);
+            peg$fail(peg$c102);
           }
         }
         if ((s4 as any) === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 60) {
-            s4 = peg$c98;
+            s4 = peg$c99;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
             if (peg$silentFails === 0) {
-              peg$fail(peg$c99);
+              peg$fail(peg$c100);
             }
           }
         }
@@ -4427,7 +4456,7 @@ function peg$parse(input: string, options?: IParseOptions) {
           } else {
             s4 = peg$FAILED;
             if (peg$silentFails === 0) {
-              peg$fail(peg$c72);
+              peg$fail(peg$c73);
             }
           }
           if ((s4 as any) !== peg$FAILED) {
@@ -4448,7 +4477,7 @@ function peg$parse(input: string, options?: IParseOptions) {
     }
     if ((s1 as any) !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c103(s1);
+      s1 = peg$c104(s1);
     }
     s0 = s1;
 
@@ -4460,12 +4489,12 @@ function peg$parse(input: string, options?: IParseOptions) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c104;
+      s1 = peg$c105;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c105);
+        peg$fail(peg$c106);
       }
     }
     if ((s1 as any) !== peg$FAILED) {
@@ -4477,17 +4506,17 @@ function peg$parse(input: string, options?: IParseOptions) {
       }
       if ((s2 as any) !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c104;
+          s3 = peg$c105;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c105);
+            peg$fail(peg$c106);
           }
         }
         if ((s3 as any) !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c106(s2);
+          s1 = peg$c107(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4514,12 +4543,12 @@ function peg$parse(input: string, options?: IParseOptions) {
       s1 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s2 = peg$c104;
+        s2 = peg$c105;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
         if (peg$silentFails === 0) {
-          peg$fail(peg$c105);
+          peg$fail(peg$c106);
         }
       }
       if ((s2 as any) === peg$FAILED) {
@@ -4536,7 +4565,7 @@ function peg$parse(input: string, options?: IParseOptions) {
         s2 = peg$parseSourceCharacter();
         if ((s2 as any) !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c107();
+          s1 = peg$c108();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4560,12 +4589,12 @@ function peg$parse(input: string, options?: IParseOptions) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s2 = peg$c108;
+      s2 = peg$c109;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c109);
+        peg$fail(peg$c110);
       }
     }
     if ((s2 as any) !== peg$FAILED) {
@@ -4575,7 +4604,7 @@ function peg$parse(input: string, options?: IParseOptions) {
       } else {
         s3 = peg$FAILED;
         if (peg$silentFails === 0) {
-          peg$fail(peg$c72);
+          peg$fail(peg$c73);
         }
       }
       if ((s3 as any) !== peg$FAILED) {
@@ -4591,7 +4620,7 @@ function peg$parse(input: string, options?: IParseOptions) {
     }
     if ((s1 as any) !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c110(s1);
+      s1 = peg$c111(s1);
     }
     s0 = s1;
 
@@ -4603,19 +4632,19 @@ function peg$parse(input: string, options?: IParseOptions) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c108;
+      s1 = peg$c109;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c109);
+        peg$fail(peg$c110);
       }
     }
     if ((s1 as any) !== peg$FAILED) {
       s2 = peg$parseLineTerminatorSequence();
       if ((s2 as any) !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c111();
+        s1 = peg$c112();
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4632,13 +4661,13 @@ function peg$parse(input: string, options?: IParseOptions) {
   function peg$parseLineTerminator(): any {
     let s0;
 
-    if (peg$c112.test(input.charAt(peg$currPos))) {
+    if (peg$c113.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c113);
+        peg$fail(peg$c114);
       }
     }
 
@@ -4650,52 +4679,52 @@ function peg$parse(input: string, options?: IParseOptions) {
 
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 10) {
-      s0 = peg$c115;
+      s0 = peg$c116;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c116);
+        peg$fail(peg$c117);
       }
     }
     if ((s0 as any) === peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c117) {
-        s0 = peg$c117;
+      if (input.substr(peg$currPos, 2) === peg$c118) {
+        s0 = peg$c118;
         peg$currPos += 2;
       } else {
         s0 = peg$FAILED;
         if (peg$silentFails === 0) {
-          peg$fail(peg$c118);
+          peg$fail(peg$c119);
         }
       }
       if ((s0 as any) === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 13) {
-          s0 = peg$c119;
+          s0 = peg$c120;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c120);
+            peg$fail(peg$c121);
           }
         }
         if ((s0 as any) === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 8232) {
-            s0 = peg$c121;
+            s0 = peg$c122;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
             if (peg$silentFails === 0) {
-              peg$fail(peg$c122);
+              peg$fail(peg$c123);
             }
           }
           if ((s0 as any) === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 8233) {
-              s0 = peg$c123;
+              s0 = peg$c124;
               peg$currPos++;
             } else {
               s0 = peg$FAILED;
               if (peg$silentFails === 0) {
-                peg$fail(peg$c124);
+                peg$fail(peg$c125);
               }
             }
           }
@@ -4706,7 +4735,7 @@ function peg$parse(input: string, options?: IParseOptions) {
     if ((s0 as any) === peg$FAILED) {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c114);
+        peg$fail(peg$c115);
       }
     }
 
@@ -4722,7 +4751,7 @@ function peg$parse(input: string, options?: IParseOptions) {
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c72);
+        peg$fail(peg$c73);
       }
     }
 
@@ -4745,7 +4774,7 @@ function peg$parse(input: string, options?: IParseOptions) {
     }
     if ((s1 as any) !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c125(s1);
+      s1 = peg$c126(s1);
     }
     s0 = s1;
 
@@ -4755,47 +4784,47 @@ function peg$parse(input: string, options?: IParseOptions) {
   function peg$parsechar(): any {
     let s0, s1, s2;
 
-    if (peg$c126.test(input.charAt(peg$currPos))) {
+    if (peg$c127.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c127);
+        peg$fail(peg$c128);
       }
     }
     if ((s0 as any) === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c128) {
-        s1 = peg$c128;
+      if (input.substr(peg$currPos, 2) === peg$c129) {
+        s1 = peg$c129;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
         if (peg$silentFails === 0) {
-          peg$fail(peg$c129);
+          peg$fail(peg$c130);
         }
       }
       if ((s1 as any) !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c130();
+        s1 = peg$c131();
       }
       s0 = s1;
       if ((s0 as any) === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c108;
+          s1 = peg$c109;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
           if (peg$silentFails === 0) {
-            peg$fail(peg$c109);
+            peg$fail(peg$c110);
           }
         }
         if ((s1 as any) !== peg$FAILED) {
           s2 = peg$parse_newlines();
           if ((s2 as any) !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c111();
+            s1 = peg$c112();
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -4808,17 +4837,17 @@ function peg$parse(input: string, options?: IParseOptions) {
         if ((s0 as any) === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 92) {
-            s1 = peg$c108;
+            s1 = peg$c109;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
             if (peg$silentFails === 0) {
-              peg$fail(peg$c109);
+              peg$fail(peg$c110);
             }
           }
           if ((s1 as any) !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c131();
+            s1 = peg$c132();
           }
           s0 = s1;
         }
@@ -4842,7 +4871,7 @@ function peg$parse(input: string, options?: IParseOptions) {
     if ((s0 as any) === peg$FAILED) {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c132);
+        peg$fail(peg$c133);
       }
     }
 
@@ -4869,7 +4898,7 @@ function peg$parse(input: string, options?: IParseOptions) {
     if ((s0 as any) === peg$FAILED) {
       s1 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c133);
+        peg$fail(peg$c134);
       }
     }
 
@@ -4879,13 +4908,13 @@ function peg$parse(input: string, options?: IParseOptions) {
   function peg$parse_newline(): any {
     let s0;
 
-    if (peg$c134.test(input.charAt(peg$currPos))) {
+    if (peg$c135.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c135);
+        peg$fail(peg$c136);
       }
     }
 
@@ -4895,13 +4924,13 @@ function peg$parse(input: string, options?: IParseOptions) {
   function peg$parse_whitespace(): any {
     let s0;
 
-    if (peg$c136.test(input.charAt(peg$currPos))) {
+    if (peg$c137.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c137);
+        peg$fail(peg$c138);
       }
     }
 
@@ -4951,13 +4980,13 @@ function peg$parse(input: string, options?: IParseOptions) {
   function peg$parseLl(): any {
     let s0;
 
-    if (peg$c138.test(input.charAt(peg$currPos))) {
+    if (peg$c139.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c139);
+        peg$fail(peg$c140);
       }
     }
 
@@ -4967,13 +4996,13 @@ function peg$parse(input: string, options?: IParseOptions) {
   function peg$parseLm(): any {
     let s0;
 
-    if (peg$c140.test(input.charAt(peg$currPos))) {
+    if (peg$c141.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c141);
+        peg$fail(peg$c142);
       }
     }
 
@@ -4983,13 +5012,13 @@ function peg$parse(input: string, options?: IParseOptions) {
   function peg$parseLo(): any {
     let s0;
 
-    if (peg$c142.test(input.charAt(peg$currPos))) {
+    if (peg$c143.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c143);
+        peg$fail(peg$c144);
       }
     }
 
@@ -4999,13 +5028,13 @@ function peg$parse(input: string, options?: IParseOptions) {
   function peg$parseLt(): any {
     let s0;
 
-    if (peg$c144.test(input.charAt(peg$currPos))) {
+    if (peg$c145.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c145);
+        peg$fail(peg$c146);
       }
     }
 
@@ -5015,13 +5044,13 @@ function peg$parse(input: string, options?: IParseOptions) {
   function peg$parseLu(): any {
     let s0;
 
-    if (peg$c146.test(input.charAt(peg$currPos))) {
+    if (peg$c147.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c147);
+        peg$fail(peg$c148);
       }
     }
 
@@ -5031,13 +5060,13 @@ function peg$parse(input: string, options?: IParseOptions) {
   function peg$parseNl(): any {
     let s0;
 
-    if (peg$c148.test(input.charAt(peg$currPos))) {
+    if (peg$c149.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c149);
+        peg$fail(peg$c150);
       }
     }
 
@@ -5047,13 +5076,13 @@ function peg$parse(input: string, options?: IParseOptions) {
   function peg$parseNd(): any {
     let s0;
 
-    if (peg$c150.test(input.charAt(peg$currPos))) {
+    if (peg$c151.test(input.charAt(peg$currPos))) {
       s0 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
       if (peg$silentFails === 0) {
-        peg$fail(peg$c151);
+        peg$fail(peg$c152);
       }
     }
 
@@ -5070,6 +5099,8 @@ function peg$parse(input: string, options?: IParseOptions) {
     }
     return str;
   }
+
+  const edgeops: { operator: '--' | '->'; location: IFileRange }[] = [];
 
   peg$result = peg$startRuleFunction();
 


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

Fixed so that an exception will occur if there is a discrepancy between the graph type and edge notation as shown below.

```dot
graph {
  a -> b;
}
```

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
