### PR TITLE
export convert method to allow downstream adopters to leverage it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { SyntaxError } from './dot.peggy';
 export { AST } from './ast';
+export { convert } from './convert'
 export { parse } from './parse';
 export { dot } from './dot';


### PR DESCRIPTION
<!-- Thank you for your contribution to ts-graphviz! Please replace {Please write here} with your description -->

### What was a problem

Working on https://github.com/redotjs/redot/pull/22
I'm considering building on top of ts-graphviz.
A particular use case I have is to be able to go from a manually generated/updated AST back to a dot (text) file.
https://github.com/ts-graphviz/ts-graphviz supports this through `toDot`, but this requires the class based version of the dot graph.
Exporting `convert` allows for `AST` -- `convert` -> Graph -- `toDot` --> Dot file flow, without copying and pasting `convert` method into another project.

### How this PR fixes the problem

By exporting the method so it can be leveraged down stream

### Check lists

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

An alternative path, to compile the AST directly, rather than going through the class/graph representation, could also work.
But could be more complex, and cause duplication.